### PR TITLE
added a public and private howmanyipsin command

### DIFF
--- a/bot/slack.py
+++ b/bot/slack.py
@@ -17,6 +17,7 @@ from commands.tip import get_random_tip
 from commands.topchannels import get_recommended_channels
 from commands.welcome import welcome_user
 from commands.zen import import_this
+from commands.network import how_many_ips
 
 Message = namedtuple('Message', 'giverid channel text')
 
@@ -32,11 +33,14 @@ PUBLIC_BOT_COMMANDS = dict(age=pybites_age,
                            add=add_command,
                            help=create_commands_table,
                            tip=get_random_tip,
-                           topchannels=get_recommended_channels)
+                           topchannels=get_recommended_channels,
+                           howmanyipsin=how_many_ips, # public and private
+                           )
 PRIVATE_BOT_COMMANDS = dict(feed=get_pybites_last_entries,  # takes up space
                             doc=doc_command,
                             help=create_commands_table,  # have everywhere
                             karma=get_karma,
+                            howmanyipsin=how_many_ips, # public and private
                             )
 
 

--- a/bot/slack.py
+++ b/bot/slack.py
@@ -34,13 +34,13 @@ PUBLIC_BOT_COMMANDS = dict(age=pybites_age,
                            help=create_commands_table,
                            tip=get_random_tip,
                            topchannels=get_recommended_channels,
-                           howmanyipsin=how_many_ips, # public and private
+                           howmanyipsin=how_many_ips,
                            )
 PRIVATE_BOT_COMMANDS = dict(feed=get_pybites_last_entries,  # takes up space
                             doc=doc_command,
                             help=create_commands_table,  # have everywhere
                             karma=get_karma,
-                            howmanyipsin=how_many_ips, # public and private
+                            howmanyipsin=how_many_ips,
                             )
 
 

--- a/commands/network.py
+++ b/commands/network.py
@@ -1,0 +1,33 @@
+from ipaddress import ip_network
+
+
+def how_many_ips(**kwargs: dict) -> str:
+    """Print the number of individual ip addresses that are within the 
+    provided network.
+
+    The provided network can be given using either CIDR notation 
+    as in '192.168.0.0/24', 
+    using a netmask as in '192.168.0.0/255.255.255.0', 
+    or using a wildcard mask as in '192.168.0.0/0.0.0.255'.
+
+    EXAMPLE USAGE: '@karmabot howmanyipsin 192.168.0.0/23'
+
+    **If any host bits are set in the network you provide, they will 
+    automatically be coerced to zero(s) in order to form a valid network.
+    """
+    user = kwargs.get('user')
+    msg_text = kwargs.get('text') # msg_text should just be the ip network,
+                                  # for example, '192.168.0.0/23'
+
+    num_of_ips = ip_network(msg_text, strict=False).num_addresses
+    return ('Hello {}!\nThe IP network {} '
+            'contains {} IP addresses.'.format(user, msg_text, num_of_ips))
+
+
+if __name__ == '__main__':
+    # standalone test
+    user, text = 'bob', '192.168.0.0/23'
+    kwargs = dict(user=user,
+                  text=text)
+    output = how_many_ips(**kwargs)
+    print(output)


### PR DESCRIPTION
This new command could be used to easily and quickly find out how many individual IP addresses are contained within a given network.

For example,
A user could type in a public or private channel any of the below commands:

@karmabot howmanyipsin 192.138.0.0/24
@karmabot howmanyipsin 192.138.0.0/255.255.255.0
@karmabot howmanyipsin 192.138.0.0/0.0.0.255

And Karmabot would print out a message to the user telling them the number of individual IPs in that network.

This is just a simple start. I would like to add many more networking related commands that would be useful for anyone to quickly get answers to network related questions.